### PR TITLE
Update FreeVario and ACD driver

### DIFF
--- a/src/Device/Driver/FreeVario.cpp
+++ b/src/Device/Driver/FreeVario.cpp
@@ -12,13 +12,9 @@
 #include "Units/System.hpp"
 #include "Operation/Operation.hpp"
 #include "LogFile.hpp"
-#include "Interface.hpp"
-#include "CalculationThread.hpp"
 #include "Protection.hpp"
 #include "Input/InputEvents.hpp"
 #include <iostream>
-
-using std::string_view_literals::operator""sv;
 
 /*
  * Commands via NMEA from FreeVario Device to XCSoar:
@@ -37,11 +33,8 @@ using std::string_view_literals::operator""sv;
  *
  * Commands for NMEA compatibility with OpenVario especially variod
  * 
- * $POV,C,STF*4B  -- if this command is received it is resend to NMEA
- *                   Device 1 and Device 2 to sent variod to speed to fly
- *                   audio mode
- * $POV,C,VAR*4F  -- if this command is received it is resend to NMEA
- *                   Device 1 and Device 2 to set variod to vario audio mode
+ * $POV,C,STF*4B  -- if this command is received it is resend to NMEA Device 1 and Device 2 to sent variod to speed to fly audio mode
+ * $POV,C,VAR*4F  -- if this command is received it is resend to NMEA Device 1 and Device 2 to set variod to vario audio mode
  *  
  */
 
@@ -52,14 +45,11 @@ public:
   explicit FreeVarioDevice(Port &_port):port(_port){}
   bool ParseNMEA(const char *line,NMEAInfo &info) override;
   static bool PFVParser(NMEAInputLine &line, NMEAInfo &info, Port &port);
-  static bool POVParserAndForward(NMEAInputLine &line);
-  bool SendCmd(double value, const char *cmd, OperationEnvironment &env);
+  static bool PFVParserAndForward(NMEAInputLine &line, NMEAInfo &info, Port &port);
   bool PutMacCready(double mc, OperationEnvironment &env) override;
   bool PutBugs(double bugs, OperationEnvironment &env) override;
-  bool PutQNH(const AtmosphericPressure &pres,
-              OperationEnvironment &env) override;
-  void OnCalculatedUpdate(const MoreData &basic,
-              const DerivedInfo &calculated) override;
+  bool PutQNH(const AtmosphericPressure &pres,OperationEnvironment &env) override;
+  void OnCalculatedUpdate(const MoreData &basic, const DerivedInfo &calculated) override;
   void OnSensorUpdate(const MoreData &basic) override;
 };
 
@@ -68,37 +58,37 @@ public:
  * Is true when a valid message or false if no valid message
  */
 bool
-FreeVarioDevice::POVParserAndForward(NMEAInputLine &line)
+FreeVarioDevice::PFVParserAndForward(NMEAInputLine &line, [[maybe_unused]] NMEAInfo &info, [[maybe_unused]] Port &port)
 {
   NullOperationEnvironment env;
   bool messageValid = false;
 
   while (!line.IsEmpty() ) {
-    StaticString<4> bufferAsString;
-    char command = line.ReadOneChar();
-    char buff[4] ;
 
-    line.Read(buff,4);
-    bufferAsString.SetUTF8(buff);
-     
-    if ('C' == command && bufferAsString == _T("STF")) {
-      messageValid = true;
-      InputEvents::eventSendNMEAPort1(_T("POV,C,STF*4B"));
-      InputEvents::eventSendNMEAPort2(_T("POV,C,STF*4B"));
-      InputEvents::eventStatusMessage(_T("Speed to Fly Mode"));
-    }
-    if ('C' == command && bufferAsString == _T("VAR")) {
-      messageValid = true;
-      InputEvents::eventSendNMEAPort1(_T("POV,C,VAR*4F"));
-      InputEvents::eventSendNMEAPort2(_T("POV,C,VAR*4F"));
-      InputEvents::eventStatusMessage(_T("Vario Mode"));
-    }
+     char command = line.ReadOneChar();
+
+      char buff[4] ;
+      line.Read(buff,4);
+      StaticString<4> bufferAsString(buff);
+
+     if ( 'C' == command && strcmp("STF",bufferAsString) == 0){
+       messageValid = true;
+       InputEvents::eventSendNMEAPort1("POV,C,STF*4B");
+       InputEvents::eventSendNMEAPort2("POV,C,STF*4B");
+       InputEvents::eventStatusMessage("Speed to Fly Mode");
+     }
+     if ('C' == command && strcmp("VAR",bufferAsString) == 0){
+       messageValid = true;
+       InputEvents::eventSendNMEAPort1("POV,C,VAR*4F");
+       InputEvents::eventSendNMEAPort2("POV,C,VAR*4F");
+       InputEvents::eventStatusMessage("Vario Mode");
+     }
   }
   return messageValid;
 }
 
 /**
- * Parse NMEA message and check if it is a valid FreeVario message
+ * Parse NMEA messsage and check if it is a valid FreeVario message
  * Is true when a valid message or false if no valid message
  */
 bool
@@ -107,125 +97,152 @@ FreeVarioDevice::PFVParser(NMEAInputLine &line, NMEAInfo &info, Port &port)
   NullOperationEnvironment env;
   bool validMessage = false;
 
-  while (!line.IsEmpty()) {
+  while (!line.IsEmpty() ) {
 
     char type = line.ReadOneChar();
     char subCommand = line.ReadOneChar();
 
-    if (subCommand == '\0')
-      return validMessage;  // from now the string is invalid...
+    if (type == '\0')break;
+    if (subCommand == '\0')break;
 
-    switch (type) {
-    case '\0':  // from now the string is invalid or finished
-      return validMessage;
-    case 'M': {
-      if (subCommand == 'S') {
-        double mcIn;
-        if (line.ReadChecked(mcIn)) {
-          info.settings.ProvideMacCready(mcIn, info.clock);
-          validMessage = true;
-        }
-      }
+       switch (type) {
+             case 'M': {
+               if (subCommand == 'S'){
 
-      else if (subCommand == 'U') {
-        double new_mc = std::min(info.settings.mac_cready + 0.1, 5.0);
-        info.settings.ProvideMacCready(new_mc, info.clock);
-        validMessage = true;
-      }
+                   double mcIn;
+                   bool mcReadOk = line.ReadChecked(mcIn);
 
-      else if (subCommand == 'D') {
-        double new_mc = std::max(info.settings.mac_cready - 0.1, 0.0);
-        info.settings.ProvideMacCready(new_mc, info.clock);
-        validMessage = true;
-      }
-      break;
-    }
-    case 'B': {
-      if (subCommand == 'S') {
-        double bugsIn;
-        if (line.ReadChecked(bugsIn)) {
-          info.settings.ProvideBugs((100 - bugsIn) / 100., info.clock);
-          validMessage = true;
-        }
-      }
-      break;
-    }
+                   if (subCommand == 'S' && mcReadOk){
+                     info.settings.ProvideMacCready(mcIn,info.clock);
+                     validMessage = true;
+                   }
+               }
 
-    case 'Q': {
-      if (subCommand == 'S') {
-        double qnhIn;
-        if (line.ReadChecked(qnhIn)) {
-          AtmosphericPressure pres = info.static_pressure.HectoPascal(qnhIn);
-          info.settings.ProvideQNH(pres, info.clock);
-          validMessage = true;
-        }
-      }
-      break;
-    }
+               else if (subCommand == 'U'){
 
-    case 'F': {
-      if (subCommand == 'S') {
-        info.switch_state.flight_mode = SwitchState::FlightMode::CRUISE;
-        validMessage = true;
-      } else if (subCommand == 'C') {
-        info.switch_state.flight_mode = SwitchState::FlightMode::CIRCLING;
-        validMessage = true;
-      }
-      break;
-    }
+                   double mc = info.settings.mac_cready;
+                   double newmc = mc + 0.1;
+                   // Check for upper range
+                   if (newmc > 5.0){newmc = 5.0;}
+                   info.settings.ProvideMacCready(newmc,info.clock);
+                   validMessage = true;
+               }
 
-    case 'S': {
-      if (subCommand == 'S') {
-        char nmeaOutbuffer[80];
-        int soundState;
-        bool stateOK = line.ReadChecked(soundState);
-        if (stateOK)
-          sprintf(nmeaOutbuffer, "PFV,MUT,%d", soundState);
-        PortWriteNMEA(port, nmeaOutbuffer, env);
-        validMessage = true;
-      }
-      break;
-    }
+               else if (subCommand == 'D'){
 
-    case 'A': {
-      if (subCommand == 'S') {
-        char nmeaOutbuffer[80];
-        int attenState;
-        bool stateOK = line.ReadChecked(attenState);
-        if (stateOK)
-          sprintf(nmeaOutbuffer, "PFV,ATT,%d", attenState);
-        PortWriteNMEA(port, nmeaOutbuffer, env);
-        validMessage = true;
-      }
-      break;
-    }
-    default:
-      // Just break on default
-      break;
-    }
+                   double  mc = info.settings.mac_cready;
+                   double newmc = mc - 0.1;
+                   // Check for lower Range
+                   if (newmc <= 0){newmc = 0.0;}
+                   info.settings.ProvideMacCready(newmc,info.clock);
+                   validMessage = true;
+               }
+               break;
+             }
+             case 'B': {
+                   if (subCommand == 'S'){
+                        double bugsIn;
+                        bool bugsOK = line.ReadChecked(bugsIn);
+
+                        if (subCommand == 'S' && bugsOK){
+                            info.settings.ProvideBugs((100 -bugsIn )/100.,info.clock);
+                            validMessage = true;
+                        }
+                   }
+                   break;
+               }
+
+             case 'Q': {
+                          if (subCommand == 'S'){
+                          double qnhIn;
+                          bool qnhOK = line.ReadChecked(qnhIn);
+
+                           if (subCommand == 'S' && qnhOK){
+                             AtmosphericPressure pres = info.static_pressure.HectoPascal(qnhIn);
+                             info.settings.ProvideQNH(pres, info.clock);
+                             validMessage = true;
+                            }
+                         }
+                         break;
+            }
+
+             case 'F': {
+               if (subCommand == 'S'){
+                   info.switch_state.flight_mode = SwitchState::FlightMode::CRUISE;
+                   validMessage = true;
+               }
+               else if (subCommand == 'C'){
+                 info.switch_state.flight_mode = SwitchState::FlightMode::CIRCLING;
+                 validMessage = true;
+               }
+               break;
+             }
+
+             case 'S':
+             {
+                if (subCommand == 'S'){
+                      char nmeaOutbuffer[80];
+                      int soundState;
+                      bool stateOK = line.ReadChecked(soundState);
+                      if (stateOK)
+                      sprintf(nmeaOutbuffer,"PFV,MUT,%d", soundState);
+                      PortWriteNMEA(port, nmeaOutbuffer, env);
+                      validMessage = true;
+                 }
+                  break;
+             }
+
+             case 'A':
+             {
+                if (subCommand == 'S'){
+                      char nmeaOutbuffer[80];
+                      int attenState;
+                      bool stateOK = line.ReadChecked(attenState);
+                      if (stateOK)
+                      sprintf(nmeaOutbuffer,"PFV,ATT,%d", attenState);
+                      PortWriteNMEA(port, nmeaOutbuffer, env);
+                      validMessage = true;
+                 }
+                  break;
+             }
+           default:
+           {
+             // Just break on default
+             break;
+           }
+       }
+        
   }
+
+
 
   return validMessage;
  }
 
 /**
- * Parse incoming NMEA messages to check for PFV messages
+ * Parse incomming NMEA messages to check for PFV messages
  */
 bool
 FreeVarioDevice::ParseNMEA(const char *_line, NMEAInfo &info)
 {
-  NullOperationEnvironment env;
+ NullOperationEnvironment env;
 
-  if (VerifyNMEAChecksum(_line)) {
-    NMEAInputLine line(_line);
-    const auto type = line.ReadView();
-    if (type == "$PFA"sv) {
-        return PFVParser(line, info, port);
-    } else if (type == "$POV"sv) {
-        return POVParserAndForward(line);  // no info and port necessary
-    }
-  }
-  return false;
+  if ( VerifyNMEAChecksum(_line) ){
+      NMEAInputLine lineTestPfv(_line);
+      NMEAInputLine lineTestPov(_line);
+      if ( lineTestPfv.ReadCompare("$PFV") ){
+            return PFVParser(lineTestPfv, info, port);
+      }
+      else if ( lineTestPov.ReadCompare("$POV") ){
+            return PFVParserAndForward(lineTestPov, info, port);
+      }
+      else  {
+        return false;
+        }
+   } else {
+     return false;
+   }
+
 }
 
 /*
@@ -234,8 +251,8 @@ FreeVarioDevice::ParseNMEA(const char *_line, NMEAInfo &info)
  * vario values
  */
 void
-FreeVarioDevice::OnSensorUpdate(const MoreData &basic)
-{
+FreeVarioDevice::OnSensorUpdate(const MoreData &basic){
+
    NullOperationEnvironment env;
    char nmeaOutbuffer[80];
 
@@ -243,84 +260,89 @@ FreeVarioDevice::OnSensorUpdate(const MoreData &basic)
      sprintf(nmeaOutbuffer,"PFV,VAR,%f", basic.total_energy_vario);
      PortWriteNMEA(port, nmeaOutbuffer, env);
    }
+
+     sprintf(nmeaOutbuffer,"PFV,VAN,%f", basic.netto_vario);
+     PortWriteNMEA(port, nmeaOutbuffer, env);
 }
 
-
 /*
- * Always send the calculated updated values to the FreeVario to have a good
- * refresh rate on the external device
+ * Always send the calculated updated values to the FreeVario to have a good refresh rate
+ * on the external device
  */
 void
-FreeVarioDevice::OnCalculatedUpdate(const MoreData &basic,
-  const DerivedInfo &calculated)
+FreeVarioDevice::OnCalculatedUpdate(const MoreData &basic,const DerivedInfo &calculated)
 {
+
   NullOperationEnvironment env;
 
   char nmeaOutbuffer[80];
 
- if (basic.baro_altitude_available.IsValid()){
-   sprintf(nmeaOutbuffer,"PFV,HIG,%f", basic.baro_altitude);
-   PortWriteNMEA(port, nmeaOutbuffer, env);
- } else if (basic.gps_altitude_available.IsValid()){
-   sprintf(nmeaOutbuffer,"PFV,HIG,%f", basic.gps_altitude);
-   PortWriteNMEA(port, nmeaOutbuffer, env);
- } else {
-   sprintf(nmeaOutbuffer,"PFV,HIG,%f", 0.0);
-   PortWriteNMEA(port, nmeaOutbuffer, env);
- }
+    if (basic.baro_altitude_available.IsValid()){
+      sprintf(nmeaOutbuffer,"PFV,HIG,%f", basic.baro_altitude);
+      PortWriteNMEA(port, nmeaOutbuffer, env);
+    }
+    else if (basic.gps_altitude_available.IsValid()){
+      sprintf(nmeaOutbuffer,"PFV,HIG,%f", basic.gps_altitude);
+      PortWriteNMEA(port, nmeaOutbuffer, env);
+    }
+    else {
+      sprintf(nmeaOutbuffer,"PFV,HIG,%f", 0.0);
+      PortWriteNMEA(port, nmeaOutbuffer, env);
+    }
 
- if (calculated.altitude_agl_valid){
-   sprintf(nmeaOutbuffer,"PFV,HAG,%f", calculated.altitude_agl);
-   PortWriteNMEA(port, nmeaOutbuffer, env);
- }
-
-  bool tempAvil = basic.temperature_available;
-  if (tempAvil){
-    double temp = basic.temperature.ToCelsius();
-    sprintf(nmeaOutbuffer,"PFV,TEM,%f", temp);
-    PortWriteNMEA(port, nmeaOutbuffer, env);
-  }
-
-  double trueAirspeedKmh = ((basic.true_airspeed * 60 * 60) / 1000);
-  sprintf(nmeaOutbuffer,"PFV,TAS,%f", trueAirspeedKmh);
-  PortWriteNMEA(port, nmeaOutbuffer, env);
-
-  if (basic.ground_speed_available.IsValid()){
-    double groundSpeed = ((basic.ground_speed * 60 * 60) / 1000);;
-    sprintf(nmeaOutbuffer,"PFV,GRS,%f", groundSpeed);
-    PortWriteNMEA(port, nmeaOutbuffer, env);
-  } else {
-    sprintf(nmeaOutbuffer,"PFV,GRS,%d", -1);
-    PortWriteNMEA(port, nmeaOutbuffer, env);
-  }
-
-  double stfKmh = ((calculated.V_stf * 60 * 60) / 1000);
-  sprintf(nmeaOutbuffer,"PFV,STF,%f", stfKmh);
-  PortWriteNMEA(port, nmeaOutbuffer, env);
-
-  if (calculated.circling){
-    sprintf(nmeaOutbuffer,"PFV,MOD,%s", "C");
-    PortWriteNMEA(port, nmeaOutbuffer, env);
-  } else {
-    sprintf(nmeaOutbuffer,"PFV,MOD,%s", "S");
-    PortWriteNMEA(port, nmeaOutbuffer, env);
-  }
-
-  // vario average last 30 secs
-  sprintf(nmeaOutbuffer,"PFV,VAA,%f",calculated.average);
-  PortWriteNMEA(port, nmeaOutbuffer, env);
-
-  if (basic.settings.mac_cready_available.IsValid()){
-        double externalMC = basic.settings.mac_cready;
-        sprintf(nmeaOutbuffer,"PFV,MCE,%0.2f", (double)externalMC);
+      if (calculated.altitude_agl_valid){
+        sprintf(nmeaOutbuffer,"PFV,HAG,%f", calculated.altitude_agl);
         PortWriteNMEA(port, nmeaOutbuffer, env);
-  }
+       }
 
-  if (basic.settings.qnh_available.IsValid()){
-    double qnhHp = basic.settings.qnh.GetHectoPascal();
-    sprintf(nmeaOutbuffer,"PFV,QNH,%f",qnhHp);
-    PortWriteNMEA(port, nmeaOutbuffer, env);
-  }
+      bool tempAvil = basic.temperature_available;
+      if (tempAvil){
+        double temp = basic.temperature.ToCelsius();
+        sprintf(nmeaOutbuffer,"PFV,TEM,%f", temp);
+        PortWriteNMEA(port, nmeaOutbuffer, env);
+      }
+
+     double trueAirspeedKmh = ((basic.true_airspeed * 60 * 60) / 1000);
+     sprintf(nmeaOutbuffer,"PFV,TAS,%f", trueAirspeedKmh);
+     PortWriteNMEA(port, nmeaOutbuffer, env);
+
+     if (basic.ground_speed_available.IsValid()){
+       double groundSpeed = ((basic.ground_speed * 60 * 60) / 1000);;
+       sprintf(nmeaOutbuffer,"PFV,GRS,%f", groundSpeed);
+       PortWriteNMEA(port, nmeaOutbuffer, env);
+     } else {
+       sprintf(nmeaOutbuffer,"PFV,GRS,%d", -1);
+       PortWriteNMEA(port, nmeaOutbuffer, env);
+     }
+
+     double stfKmh = ((calculated.V_stf * 60 * 60) / 1000);
+     sprintf(nmeaOutbuffer,"PFV,STF,%f", stfKmh);
+     PortWriteNMEA(port, nmeaOutbuffer, env);
+
+     if (calculated.circling){
+       sprintf(nmeaOutbuffer,"PFV,MOD,%s", "C");
+       PortWriteNMEA(port, nmeaOutbuffer, env);
+     } else {
+       sprintf(nmeaOutbuffer,"PFV,MOD,%s", "S");
+       PortWriteNMEA(port, nmeaOutbuffer, env);
+     }
+
+     // vario average last 30 secs
+     sprintf(nmeaOutbuffer,"PFV,VAA,%f",calculated.average);
+     PortWriteNMEA(port, nmeaOutbuffer, env);
+
+     if (basic.settings.mac_cready_available.IsValid() ){
+           double externalMC = basic.settings.mac_cready;
+           sprintf(nmeaOutbuffer,"PFV,MCE,%0.2f", (double)externalMC);
+           PortWriteNMEA(port, nmeaOutbuffer, env);
+     }
+ 
+     if (basic.settings.qnh_available.IsValid()){
+       double qnhHp = basic.settings.qnh.GetHectoPascal();
+       sprintf(nmeaOutbuffer,"PFV,QNH,%f",qnhHp);
+       PortWriteNMEA(port, nmeaOutbuffer, env);
+     }
+ 
 }
 
 /*
@@ -328,44 +350,37 @@ FreeVarioDevice::OnCalculatedUpdate(const MoreData &basic,
  *  be informed about MC changes doen in XCSoar
  */
 bool
-FreeVarioDevice::SendCmd(double value, const char *cmd,
-  OperationEnvironment &env)
+FreeVarioDevice::PutMacCready(double mc, OperationEnvironment &env)
 {
-  if (!EnableNMEA(env)) {
-    return false;
-  }
+  if (!EnableNMEA(env)){return false;}
   char nmeaOutbuffer[80];
-  sprintf(nmeaOutbuffer, cmd, value);
+  sprintf(nmeaOutbuffer,"PFV,MCI,%0.2f", (double)mc);
   PortWriteNMEA(port, nmeaOutbuffer, env);
   return true;
 }
 
 bool
-FreeVarioDevice::PutMacCready(double mc, OperationEnvironment &env)
-{
-  return SendCmd(mc, "PFV,MCI,%0.2f", env);
+FreeVarioDevice::PutBugs(double bugs,OperationEnvironment &env){
+  if (!EnableNMEA(env)){return false;}
+     char nmeaOutbuffer[80];
+     double bugsAsPercentage = (1 - bugs) * 100;
+     sprintf(nmeaOutbuffer,"PFV,BUG,%f",bugsAsPercentage);
+     PortWriteNMEA(port, nmeaOutbuffer, env);
+     return true;
 }
 
 bool
-FreeVarioDevice::PutBugs(double bugs,OperationEnvironment &env)
-{
-  double bugsAsPercentage = (1 - bugs) * 100;
-  return SendCmd(bugsAsPercentage, "PFV,BUG,%f", env);
+FreeVarioDevice::PutQNH(const AtmosphericPressure &pres,OperationEnvironment &env) {
+  if (!EnableNMEA(env)){return false;}
+      char nmeaOutbuffer[80];
+      sprintf(nmeaOutbuffer,"PFV,QNH,%f",pres.GetHectoPascal());
+      PortWriteNMEA(port, nmeaOutbuffer, env);
+      return true;
 }
-
-bool
-FreeVarioDevice::PutQNH(const AtmosphericPressure &pres,
-  OperationEnvironment &env)
-{
-  return SendCmd(pres.GetHectoPascal(), "PFV,QNH,%f", env);
-}
-
 
 static Device *
-FreeVarioCreateOnPort([[maybe_unused]] const DeviceConfig &config,
-  Port &com_port)
-{
-  return new FreeVarioDevice(com_port);
+FreeVarioCreateOnPort([[maybe_unused]] const DeviceConfig &config, Port &com_port){
+  return new FreeVarioDevice(com_port);  
 }
 
 const struct DeviceRegister free_vario_driver = {


### PR DESCRIPTION
- updated the FreeVario driver
- updated ACD driver: if, in addition to the ACD, other devices are connected to XCSoar that can send a QNH to XCSoar, then the ACD synchronizes with this device using OnCalculatedUpdate. This ensures that the ACD does not use a different value for the QNH.